### PR TITLE
Criação de diretórios no setup

### DIFF
--- a/models/behaviors/meio_upload.php
+++ b/models/behaviors/meio_upload.php
@@ -274,12 +274,15 @@ class MeioUploadBehavior extends ModelBehavior {
 			$options['dir'] = rtrim($this->_replaceTokens($model, $options['dir'], $field, $tokens), DS);
 			$options['uploadName'] = rtrim($this->_replaceTokens($model, $options['uploadName'], $field, $tokens), DS);
 
-			// Create the folders for the uploads
-			// Create the folders for the uploads
-			if (!empty($options['thumbsizes'])) {
-				$this->_createFolders($options['dir'], $options['thumbnailDir'], array_keys($options['thumbsizes']));
-			} else {
-				$this->_createFolders($options['dir'], $options['thumbnailDir'], array());
+			// Create the folders for the uploads only if you want
+			if($options['createDirectory'])
+			{
+				// Create the folders for the uploads
+				if (!empty($options['thumbsizes'])) {
+					$this->_createFolders($options['dir'], $options['thumbnailDir'], array_keys($options['thumbsizes']));
+				} else {
+					$this->_createFolders($options['dir'], $options['thumbnailDir'], array());
+				}
 			}
 
 			// Replace tokens in the fields names


### PR DESCRIPTION
Há uma variável de configuração que (ao que parece) habilita ou não a criação de diretórios para os uploads e os thumbs, que é a variável "createDirectory", porém no setup é invocado o método para criação desses diretórios sem checar a variável.

Apenas adicionei um teste antes de invocar estes métodos.

Espero ajudar.
