### PR TITLE
the MeioUpload version 4.0 did not work so well when i wrote unit tests for the models which use MeioUpload version 4.0

### DIFF
--- a/Model/Behavior/MeioUploadBehavior.php
+++ b/Model/Behavior/MeioUploadBehavior.php
@@ -130,6 +130,11 @@ class MeioUploadBehavior extends ModelBehavior {
 			'check' => true,
 			'last' => true
 		),
+		'HttpPost' => array(
+			'rule' => array('uploadCheckHttpPost'),
+			'check' => true,
+			'last' => true
+		),
 	);
 
 /**
@@ -216,6 +221,9 @@ class MeioUploadBehavior extends ModelBehavior {
 			),
 			'MaxHeight' => array(
 				'message' => __d('meio_upload', 'Image height is larger than maximum allowed.')
+			),
+			'HttpPost' => array(
+				'message' => __d('meio_upload', 'The uploaded file did not use http POST. Suspected security issue.')
 			)
 		);
 		$this->defaultValidations = $this->_arrayMerge($this->defaultValidations, $messages);
@@ -1183,10 +1191,7 @@ class MeioUploadBehavior extends ModelBehavior {
  */
 	function _copyFileFromTemp($tmpName, $saveAs, $filePermission) {
 		$results = true;
-		if (!is_uploaded_file($tmpName)) {
-			$results = __d('meio_upload', 'The uploaded file did not use http POST. Suspected security issue.');
-			return $results;
-		}
+		
 		$file = new File($tmpName, $saveAs);
 		$temp = new File($saveAs, true, $filePermission);
 		if (!$temp->write($file->read())) {

--- a/Model/Behavior/MeioUploadBehavior.php
+++ b/Model/Behavior/MeioUploadBehavior.php
@@ -1174,7 +1174,8 @@ class MeioUploadBehavior extends ModelBehavior {
 	function _copyFileFromTemp($tmpName, $saveAs, $filePermission) {
 		$results = true;
 		if (!is_uploaded_file($tmpName)) {
-			return false;
+			$results = __d('meio_upload', 'The uploaded file did not use http POST. Suspected security issue.');
+			return $results;
 		}
 		$file = new File($tmpName, $saveAs);
 		$temp = new File($saveAs, true, $filePermission);

--- a/Model/Behavior/MeioUploadBehavior.php
+++ b/Model/Behavior/MeioUploadBehavior.php
@@ -443,6 +443,16 @@ class MeioUploadBehavior extends ModelBehavior {
  * @access public
  */
 	function uploadCheckDir(&$model, $data) {
+		/**
+		 * when running unit tests for model, the current working directory is not necessarily WWW_ROOT
+		 * the code is_dir assumed that the current working directory is WWW_ROOT
+		 * if current working directory is NOT WWW_ROOT, we need to change it to WWW_ROOT (temporarily??)
+		 */
+		$currentWorkingDirectory = getcwd();
+		if ($currentWorkingDirectory != WWW_ROOT) {
+			chdir(WWW_ROOT);
+		}
+		
 		foreach ($data as $fieldName => $field) {
 			if (!$model->validate[$fieldName]['Dir']['check']) {
 				continue;

--- a/Model/Behavior/MeioUploadBehavior.php
+++ b/Model/Behavior/MeioUploadBehavior.php
@@ -703,6 +703,28 @@ class MeioUploadBehavior extends ModelBehavior {
 	}
 
 /**
+ * Checks if the file is uploaded via HTTP POST
+ *
+ * @param object $model Reference to model
+ * @param array $data
+ * @return boolean
+ * @access public
+ */
+	function uploadCheckHttpPost(&$model, $data) {
+		
+		foreach ($data as $fieldName => $field) {
+			if (!$model->validate[$fieldName]['HttpPost']['check']) {
+				continue;
+			}
+
+			if (!empty($field['tmp_name'])) {
+				return is_uploaded_file($field['tmp_name']);
+			}
+		}
+		return true;
+	}
+
+/**
  * Uploads the files
  *
  * @param object $model Reference to model

--- a/Model/Behavior/MeioUploadBehavior.php
+++ b/Model/Behavior/MeioUploadBehavior.php
@@ -453,7 +453,7 @@ class MeioUploadBehavior extends ModelBehavior {
 				if (!is_dir($options['dir'])) {
 					if ($options['createDirectory']) {
 						$folder = &new Folder();
-						if (!$folder->create($options['dir'], $this->settings['folderPermission'])) {
+						if (!$folder->create($options['dir'], $options['folderPermission'])) {
 							trigger_error(__d('meio_upload', 'MeioUploadBehavior Error: The directory %s does not exist and cannot be created.', $options['dir']), E_USER_WARNING);
 							return false;
 						}

--- a/README.markdown
+++ b/README.markdown
@@ -56,3 +56,16 @@ The behavior code will save the uploaded file's name in the 'filename' field in 
 
 ### Deleting an uploaded file while keeping the record
 Flag the file for deletion by setting `data[Model][filename][remove]` to something non-empty, e.g. `TRUE`. The uploaded file including possible thumbnails will then be deleted together with adherent database fields upon save. Note that the record will be preserved, only the file meta-data columns will be reset.
+
+### How to run unit tests for Cake 2.0 Models which use MeioUpload 4.0 as Behavior
+
+Assuming we have a Model called Image which use MeioUpload 4.0 as Behavior.
+
+Before we run the save function in the unit test for Image, ensure that this piece of code is executed
+
+		// turn off the check to see if HTTP POST is used to upload the source file
+		$this->Image->validate['filename'] = array(
+			'HttpPost' => array(
+				'check' => false
+			)
+		);


### PR DESCRIPTION
There are 3 basic issues:

1) the use of $this->settings in uploadCheckDir is definitely wrong. So I changed that to $options as expected.

2) in unit tests, the current working directory need not necessarily be WWW_ROOT. However, in uploadCheckDir, it is assumed to be the case because the code is_dir is used. So I added code which will first check if the current working directory is indeed WWW_ROOT. If not, then chdir to the assumed directory

3) in _copyFileFromTemp, there is a check on the source file whethere it is an uploaded file using the is_uploaded_file.

In unit tests, this check will surely fail. Hence I have extracted this check into a standalone entry in the $validate array.

By default, this validation is turned on. Its index is HttpPost. The validation function is uploadCheckHttpPost.

With the above changes, cake test cases can be used on Models that have MeioUpload as one of its behaviors.

In those test cases, we need a separate line of code which will turn off the validation for HttpPost.

eg a model called Image which actsAs MeioUpload under the fieldName filename

```
    $this->Image->validate['filename'] = array(
        'HttpPost' => array(
            'check' => false
        )
    ); 
```
