### PR TITLE
Fixed bug of not creating thumb image for 'normal'. The absolute path was being assigned twice.

### DIFF
--- a/Model/Behavior/MeioUploadBehavior.php
+++ b/Model/Behavior/MeioUploadBehavior.php
@@ -906,7 +906,6 @@ class MeioUploadBehavior extends ModelBehavior {
  * @access protected
  */
 	function _createThumbnails(&$model, $data, $fieldName, $saveAs, $ext, $options) {
-		$saveAs = WWW_ROOT . $saveAs;
 		foreach ($options['thumbsizes'] as $key => $value) {
 			// Generate the name for the thumbnail
 			if (isset($options['uploadName']) && !empty($options['uploadName'])) {


### PR DESCRIPTION
Removed line 909, since the absolute path is assigned in line 918
